### PR TITLE
Adding logic to calculate weighted average cost of capital

### DIFF
--- a/crates/iex-provider/src/models.rs
+++ b/crates/iex-provider/src/models.rs
@@ -15,6 +15,39 @@ pub struct AnnualIncomeStatement {
     pub fiscal_year: u16,
     pub total_revenue: i64,
     pub net_income: i64,
+    pub interest_income: f64,
+    pub income_tax: f64,
+    pub pretax_income: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceSheet {
+    pub long_term_debt: f64,
+    pub total_current_liabilities: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BalanceSheetResponse {
+    pub balancesheet: Vec<BalanceSheet>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TreasuryRate {
+    pub value: f64
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TreasuryRateResponse { 
+    pub rate: Vec<TreasuryRate> 
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompanyStats {
+    pub shares_outstanding: i64,
+    pub marketcap: f64,
+    pub beta: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/iex-provider/src/models.rs
+++ b/crates/iex-provider/src/models.rs
@@ -13,8 +13,8 @@ pub struct AnnualCashFlow {
 #[serde(rename_all = "camelCase")]
 pub struct AnnualIncomeStatement {
     pub fiscal_year: u16,
-    pub total_revenue: i64,
-    pub net_income: i64,
+    pub total_revenue: f64,
+    pub net_income: f64,
     pub interest_income: f64,
     pub income_tax: f64,
     pub pretax_income: f64,
@@ -52,7 +52,6 @@ pub struct CompanyStats {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompanyCashFlowResponse {
-    symbol: String,
     pub cashflow: Vec<AnnualCashFlow>,
 }
 
@@ -75,7 +74,6 @@ pub struct EstimateResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EstimateResponseList {
-    pub symbol: String,
     pub estimates: Vec<EstimateResponse>,
 }
 

--- a/crates/iex-provider/src/provider.rs
+++ b/crates/iex-provider/src/provider.rs
@@ -74,15 +74,40 @@ impl<'a> Financials<'a> {
         Ok(income_statement)
     }
 
-    pub async fn request_outstanding_shares(&self) -> Result<i64> {
+    pub async fn request_company_stats(&self) -> Result<CompanyStats> {
         let url = format!(
-            "{base_url}/stock/{ticker_symbol}/stats/sharesOutstanding?token={token}",
+            "{base_url}/stock/{ticker_symbol}/stats?token={token}",
             base_url = IEX_BASE_URL,
             token = IEX_API_KEY,
             ticker_symbol = self.ticker_symbol
         );
 
-        let outstanding_shares = request::get::<i64>(&url).await?;
-        Ok(outstanding_shares)
+        let stats = request::get::<CompanyStats>(&url).await.unwrap();
+        Ok(stats)
+    }
+
+    pub async fn request_balance_sheet(&self) -> Result<BalanceSheetResponse> {
+        let url = format!(
+            "{base_url}/stock/{ticker_symbol}/balance-sheet?period={period}&token={token}",
+            base_url = IEX_BASE_URL,
+            token = IEX_API_KEY,
+            ticker_symbol = self.ticker_symbol,
+            period = self.period
+        );
+
+        let balance_sheet = request::get::<BalanceSheetResponse>(&url).await.unwrap();
+        Ok(balance_sheet)
+    }
+
+    pub async fn request_ten_year_treasury_rate(&self) -> Result<f64> {
+        let url = format!(
+            "{base_url}/time-series/treasury/DGS10?token={token}",
+            base_url = IEX_BASE_URL,
+            token = IEX_API_KEY,
+        );
+
+        let response = request::get::<Vec<TreasuryRate>>(&url).await.unwrap();
+        let rate = response[0].value;
+        Ok(rate)
     }
 }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -7,14 +7,12 @@ use crate::method::DiscountedFreeCashflow;
 #[serde(crate = "rocket::serde")]
 pub struct Stock {
     pub ticker_symbol: String,
-    pub expected_return: f64,
 }
 
 impl Stock {
     pub fn new(stock: Stock) -> Self {
         Stock {
             ticker_symbol: stock.ticker_symbol,
-            expected_return: stock.expected_return,
         }
     }
 

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -22,7 +22,7 @@ impl Stock {
         let estimated_fair_value = DiscountedFreeCashflow::financials(self)
             .await?
             .adjust_projected_estimates()
-            .project_fair_value(self.expected_return, 2.50);
+            .project_fair_value(2.50);
 
         Ok(estimated_fair_value)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate rocket;
 
+mod wacc;
+
 use crate::evaluate::Stock;
 use rocket::http::{ContentType, Status};
 use rocket::response::{self, Responder, Response as RocketResponse};

--- a/src/wacc.rs
+++ b/src/wacc.rs
@@ -1,14 +1,25 @@
 use serde::{Deserialize, Serialize};
 
+// This is derived from the average S&P500 growth
+// going back to 1920s
+// Instead of polling and calculating this everytime,
+// hard-coding it to 10% yearly growth
+const PRESUMED_MARKET_GROWTH: f64 = 10.00;
+
 // Weighted Average cost of capital
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Wacc {
     pub interest_income: f64,
     pub long_term_debt: f64,
     pub total_current_liabilities: f64,
+
     pub pre_tax: f64,
     pub income_tax: f64,
+
+    pub ten_year_treasury_rate: f64,
+    pub beta: f64,
+    pub market_cap: f64,
 }
 
 impl Wacc {
@@ -16,9 +27,30 @@ impl Wacc {
         self.income_tax / self.pre_tax
     }
 
-    fn cost_to_debt(&self) -> f64 {
+    fn cost_to_debt(&self) -> (f64, f64) {
         let total_debt = self.long_term_debt + self.total_current_liabilities;
         let cost_to_debt = self.interest_income / total_debt;
-        cost_to_debt
+        (total_debt, cost_to_debt)
+    }
+
+    fn cost_of_equity(&self, total_debt: f64) -> (f64, f64) {
+        let updated_debt = self.market_cap + total_debt;
+        let total_cap_structure = total_debt / updated_debt;
+        let equity = 1.00 - total_cap_structure;
+
+        (equity, total_cap_structure)
+    }
+
+    fn capital_asset_pricing_model(&self) -> f64 {
+        self.ten_year_treasury_rate
+            + (self.beta * (PRESUMED_MARKET_GROWTH - self.ten_year_treasury_rate))
+    }
+
+    pub fn generate_wacc(&self) -> f64 {
+        let (total_debt, cost_to_debt) = self.cost_to_debt();
+        let adjusted_debt = cost_to_debt * self.effective_tax_rate();
+        let (equity, total_cap_structure) = self.cost_of_equity(total_debt);
+
+        total_cap_structure * (1.00 - adjusted_debt) + equity * self.capital_asset_pricing_model()
     }
 }

--- a/src/wacc.rs
+++ b/src/wacc.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+// Weighted Average cost of capital
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all="camelCase")]
+pub struct Wacc {
+    pub interest_income: f64,
+    pub long_term_debt: f64,
+    pub total_current_liabilities: f64,
+    pub pre_tax: f64,
+    pub income_tax: f64,
+}
+
+impl Wacc {
+    fn effective_tax_rate(&self) -> f64 {
+        self.income_tax / self.pre_tax
+    }
+
+    fn cost_to_debt(&self) -> f64 {
+        let total_debt = self.long_term_debt + self.total_current_liabilities;
+        let cost_to_debt = self.interest_income / total_debt;
+        cost_to_debt
+    }
+}


### PR DESCRIPTION
Calculating expected rate of return for a stock using a Weighted Average Cost of Capital (WACC) instead of entering a manual expected rate of return for more precise fair value calculations. 